### PR TITLE
Bugfix: Did not render correctly on iOS

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -161,7 +161,8 @@ const styles = StyleSheet.create({
   outer: {
     position: "relative",
     justifyContent: "center",
-    alignItems: "center"
+    alignItems: "center",
+    overflow: "hidden"
   },
   half: {
     position: "absolute",


### PR DESCRIPTION
For iOS there was style missing which was causing it to break. 
I added an additional style `overflow:hidden` to the outer circle to fix this. 
This does not affect the android ui.   